### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
   push:
     branches:
-      - main
+      - new-br
 
 jobs:
   build:
@@ -23,9 +23,11 @@ jobs:
           pacman -S --noconfirm base-devel pipewire &&\
           make"
 
-      - name: Get short commit SHA
+      - name: Get short commit SHA and commit count
         id: vars
-        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: | 
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "COMMIT_NUMBER=$(git rev-list --count HEAD)" >> $GITHUB_ENV
 
       - name: Create Pre-release
         id: create_release
@@ -33,7 +35,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: "build-${{ env.SHORT_SHA }}"
+          tag_name: "build-${{ env.SHORT_SHA }}-${{ env.COMMIT_NUMBER }}"
           release_name: "Build from commit ${{ env.SHORT_SHA }}"
           prerelease: true
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Build with Arch Linux
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
   push:
     branches:
-      - new-br
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
This update includes adding a number to the `tag` when creating a `release` to help sort things more intelligently.
This number is derived from the **total** number of `commits` tracked in the `repository`.
Before merging, please add a number at the end of all already created tags, like `build-SHA276-1`.
