### PR TITLE
cicd: manually creating tags to start the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-glibc:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ x86_64, aarch64 ]
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    container:
+      image: docker.io/debian:bookworm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y make pkg-config gcc libpipewire-0.3-dev
+
+      - name: Build binary
+        run: make
+
+      - name: Rename
+        run: mv awim awim-glibc-${{ matrix.arch }}
+
+      - name: Upload glibc build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: awim-glibc-${{ matrix.arch }}
+          path: ./awim-glibc-${{ matrix.arch }}
+          if-no-files-found: error
+
+  build-musl:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ x86_64, aarch64 ]
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build in alpine
+        run: |
+          docker run --rm -v $PWD:/src -w /src docker.io/alpine:3.23 \
+          sh -c "apk add --no-cache make pkgconf musl-dev pipewire-dev gcc && make"
+
+      - name: Rename
+        run: mv awim awim-musl-${{ matrix.arch }}
+
+      - name: Upload musl build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: awim-musl-${{ matrix.arch }}
+          path: ./awim-musl-${{ matrix.arch }}
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Pull request checker
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+name: Pull request checker
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Build and Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 permissions:
@@ -97,8 +97,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: build-${{ env.SHORT_SHA }}-${{ env.COMMIT_NUMBER }}
-          name: Build from commit ${{ env.SHORT_SHA }}
-          generate_release_notes: false
+          tag_name: ${{ github.ref_name }}
+          name: AWiM ${{ github.ref_name }}
+          generate_release_notes: true
           prerelease: false
           files: builds/awim-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,96 +1,28 @@
-name: Build and Release
+name: Release
 
 on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  build-glibc:
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ x86_64, aarch64 ]
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
-    container:
-      image: docker.io/debian:bookworm
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y make pkg-config gcc libpipewire-0.3-dev
-
-      - name: Build binary
-        run: make
-
-      - name: Rename
-        run: mv awim awim-glibc-${{ matrix.arch }}
-
-      - name: Upload glibc build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: awim-glibc-${{ matrix.arch }}
-          path: ./awim-glibc-${{ matrix.arch }}
-          if-no-files-found: error
-
-  build-musl:
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ x86_64, aarch64 ]
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Build in alpine
-        run: |
-          docker run --rm -v $PWD:/src -w /src docker.io/alpine:3.23 \
-          sh -c "apk add --no-cache make pkgconf musl-dev pipewire-dev gcc && make"
-
-      - name: Rename
-        run: mv awim awim-musl-${{ matrix.arch }}
-
-      - name: Upload musl build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: awim-musl-${{ matrix.arch }}
-          path: ./awim-musl-${{ matrix.arch }}
-          if-no-files-found: error
+  build:
+    uses: ./.github/workflows/build.yml
 
   release:
-    needs:
-      - build-glibc
-      - build-musl
+    needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Download all binary
+      - name: Download all binaries
         uses: actions/download-artifact@v4
         with:
           pattern: awim-*
           path: builds
           merge-multiple: true
-
-      - name: Get short commit SHA and commit count
-        id: vars
-        run: |
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "COMMIT_NUMBER=$(git rev-list --count HEAD)" >> $GITHUB_ENV
 
       - name: Create release
         uses: softprops/action-gh-release@v2.3.2

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PKG_CONFIG ?= pkg-config
 SOURCES = ./src/main.c ./src/pw.c ./src/ui.c ./src/udp.c ./src/tcp.c ./src/queue.c
 PIPEWIRE_FLAGS = $(shell $(PKG_CONFIG) --libs --cflags libpipewire-0.3)
 
-.PHONY: all musl clean
+.PHONY: all clean
 
 all: awim
 


### PR DESCRIPTION
## Before merging
**Before merging, delete old releases and tags.**
- After merging, create a tag: `git tag v0.0.1`
> this will pin the tag to the latest commit
- Push the tag to the remote repository: `git push origin --tags`

## Workflows
- `build.yml`: creation and sending to artifact, launched using ci.yml and release.yml, is not independent
- `ci.yml`: launches on pull request or manually, creates a debug build in artifact without release
- `release.yml`: launches when creating a tag of format `v1.2.3`, build release, and uploads to github releases